### PR TITLE
field_name_limit should not span two columns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,8 @@ For manual tests, update ``setup.py`` to a new version like
 ``version="1.4.4.c13"`` then run ``python setup.py sdist`` to create the python
 source package in the 'dist/' folder.
 
-With this package, manually install it into the repo to test.
+With this package, manually install it into the ``build-*`` folder in the
+repo to test.
 For example to test ``scame`` in the ``server`` repo:
 
 ```
@@ -39,6 +40,9 @@ paver lint --all
 
 `paver lint` by default will only check the files changed since master so you
 need the `--all` flag to recheck even the files which were not change.
+
+For ``docutils`` you will need to access the HTML build of the documentation
+from the actual ``build-*`` folder.
 
 
 Updating the package

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,48 @@
+docutils
+========
+
+``docutils`` takes care of transforming files from RST to HTML.
+This repository is for the ``chevah`` project.
+
+
+Development
+===========
+
+Each change needs a dedicated ticket and a dedicated branch::
+
+    $ git checkout -b TICKET_ID-short-name
+
+Create a PR and request a review.
+
+Once all the required tests are green and you have a review,
+you can merge from GitHub's merge button.
+
+The merge button will tell you if something is not right.
+
+
+Manual tests
+============
+
+For manual tests, update ``setup.py`` to a new version like
+``version="1.4.4.c13"`` then run ``python setup.py sdist`` to create the python
+source package in the 'dist/' folder.
+
+With this package, manually install it into the repo to test.
+For example to test ``scame`` in the ``server`` repo:
+
+```
+cd path/to/server/repo/base
+./build-OS-CPU/bin/python -m pip install -U
+../path/to/scame/dist/scame-package.1.2.3.tar.gz`
+paver lint --all
+```
+
+`paver lint` by default will only check the files changed since master so you
+need the `--all` flag to recheck even the files which were not change.
+
+
+Updating the package
+====================
+
+In order to have the change available in the other repos, the change should
+come with an updated version and once merged a new package to be published.

--- a/docutils.conf
+++ b/docutils.conf
@@ -8,7 +8,7 @@ generator: on
 [html4css1 writer]
 stylesheet-path: docutils/writers/html4css1/html4css1.css
 embed-stylesheet: no
-field-name-limit: 20
+field-name-limit: 30
 
 # Prevent tools/buildhtml.py from processing certain text files.
 [buildhtml application]


### PR DESCRIPTION
Scope
-----

When the field_name takes up more than 14 chars, it expands across two columns instead of staying in the one column.

See ``update_datetime:`` for event id ``20037`` as an example:
https://staging.sftpplus.com/documentation/sftpplus/latest/events/events.html#id35

Detail about the ``field_name_limit`` is at https://github.com/chevah/docutils/blob/763f19d1a33fa750659b1a7f08dc69da9df82c41/docutils/docs/user/config.txt (it states that the default is ``14`` chars)

Changes
-------

Extend the field-name-limit to 30 chars.
The longest field name is ``cryptography_library_version:``

How to try and test the changes
-------------------------------

reviewers: @adiroiban

Go to event ID ``20072`` and notice that the field does not lead to a second line.